### PR TITLE
listen to multiple xmlrpc packages in the same socket data event

### DIFF
--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -9,6 +9,7 @@ export declare class GbxClient extends Events {
     recvData: null | Buffer;
     responseLength: null | number;
     requestHandle: number;
+    dataPointer: number;
     /**
      * Creates an instance of GbxClient.
      * @memberof GbxClient
@@ -26,6 +27,7 @@ export declare class GbxClient extends Events {
      */
     connect(host?: string, port?: number): Promise<boolean>;
     private setupListeners;
+    private extractAndHandle;
     /**
      * execute a xmlrpc method call on a server
      *

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -41,6 +41,7 @@ class GbxClient extends events_1.EventEmitter {
         this.recvData = null;
         this.responseLength = null;
         this.requestHandle = 0;
+        this.dataPointer = 0;
     }
     /**
      * Connects to trackmania server
@@ -68,7 +69,7 @@ class GbxClient extends events_1.EventEmitter {
         });
         (_b = this.socket) === null || _b === void 0 ? void 0 : _b.on("data", (data) => {
             var _a;
-            if (this.isConnected === false) {
+            if (!this.isConnected) {
                 const headerSize = data.readUIntLE(0, 4);
                 const header = data.slice(4).toString("utf-8");
                 if (header.length !== headerSize && header !== "GBXRemote 2") {
@@ -81,16 +82,29 @@ class GbxClient extends events_1.EventEmitter {
                 this.emit("connect", true);
                 return;
             }
+            else {
+                this.extractAndHandle(data);
+            }
+        });
+    }
+    extractAndHandle(data) {
+        this.dataPointer = 0;
+        do {
             if (this.responseLength == null && this.recvData == null) {
-                this.responseLength = data.readUInt32LE(0);
-                this.requestHandle = data.readUInt32LE(4);
-                this.recvData = data.slice(8);
+                this.responseLength = data.readUInt32LE(this.dataPointer);
+                this.requestHandle = data.readUInt32LE(this.dataPointer + 4);
+                const endOfMessage = this.dataPointer + 8 + this.responseLength;
+                this.recvData = data.slice(this.dataPointer, endOfMessage);
+                this.dataPointer = endOfMessage;
             }
             else if (this.recvData !== null) {
-                this.recvData = Buffer.concat([this.recvData, data]);
+                const backup = this.recvData;
+                this.recvData = null;
+                this.responseLength = null;
+                return this.extractAndHandle(Buffer.concat([backup, data]));
             }
-            if (this.responseLength && this.recvData != null && this.recvData.length >= this.responseLength) {
-                const response = this.recvData;
+            if (this.responseLength && this.recvData != null && this.recvData.length >= this.responseLength + 8) {
+                const response = this.recvData.slice(8);
                 this.recvData = null;
                 this.responseLength = null;
                 const deserializer = new Deserializer();
@@ -106,7 +120,7 @@ class GbxClient extends events_1.EventEmitter {
                     });
                 }
             }
-        });
+        } while (this.dataPointer < data.length);
     }
     /**
      * execute a xmlrpc method call on a server

--- a/lib/esm/index.d.ts
+++ b/lib/esm/index.d.ts
@@ -9,6 +9,7 @@ export declare class GbxClient extends Events {
     recvData: null | Buffer;
     responseLength: null | number;
     requestHandle: number;
+    dataPointer: number;
     /**
      * Creates an instance of GbxClient.
      * @memberof GbxClient
@@ -26,6 +27,7 @@ export declare class GbxClient extends Events {
      */
     connect(host?: string, port?: number): Promise<boolean>;
     private setupListeners;
+    private extractAndHandle;
     /**
      * execute a xmlrpc method call on a server
      *

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -28,6 +28,7 @@ export class GbxClient extends Events {
         this.recvData = null;
         this.responseLength = null;
         this.requestHandle = 0;
+        this.dataPointer = 0;
     }
     /**
      * Connects to trackmania server
@@ -57,7 +58,7 @@ export class GbxClient extends Events {
         });
         (_b = this.socket) === null || _b === void 0 ? void 0 : _b.on("data", (data) => {
             var _a;
-            if (this.isConnected === false) {
+            if (!this.isConnected) {
                 const headerSize = data.readUIntLE(0, 4);
                 const header = data.slice(4).toString("utf-8");
                 if (header.length !== headerSize && header !== "GBXRemote 2") {
@@ -70,16 +71,29 @@ export class GbxClient extends Events {
                 this.emit("connect", true);
                 return;
             }
+            else {
+                this.extractAndHandle(data);
+            }
+        });
+    }
+    extractAndHandle(data) {
+        this.dataPointer = 0;
+        do {
             if (this.responseLength == null && this.recvData == null) {
-                this.responseLength = data.readUInt32LE(0);
-                this.requestHandle = data.readUInt32LE(4);
-                this.recvData = data.slice(8);
+                this.responseLength = data.readUInt32LE(this.dataPointer);
+                this.requestHandle = data.readUInt32LE(this.dataPointer + 4);
+                const endOfMessage = this.dataPointer + 8 + this.responseLength;
+                this.recvData = data.slice(this.dataPointer, endOfMessage);
+                this.dataPointer = endOfMessage;
             }
             else if (this.recvData !== null) {
-                this.recvData = Buffer.concat([this.recvData, data]);
+                const backup = this.recvData;
+                this.recvData = null;
+                this.responseLength = null;
+                return this.extractAndHandle(Buffer.concat([backup, data]));
             }
-            if (this.responseLength && this.recvData != null && this.recvData.length >= this.responseLength) {
-                const response = this.recvData;
+            if (this.responseLength && this.recvData != null && this.recvData.length >= this.responseLength + 8) {
+                const response = this.recvData.slice(8);
                 this.recvData = null;
                 this.responseLength = null;
                 const deserializer = new Deserializer();
@@ -95,7 +109,7 @@ export class GbxClient extends Events {
                     });
                 }
             }
-        });
+        } while (this.dataPointer < data.length);
     }
     /**
      * execute a xmlrpc method call on a server


### PR DESCRIPTION
Sometimes multiple xmlrpc calls happen in the same data event of the nodejs net.Socket. This causes the gbx client to miss some callbacks for example.